### PR TITLE
Add home-manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,20 @@ paru -S trmt
 <br>
 
 **Using Flakes (Nix)**
-Add `trmt` to your flake as an input, and then add it to your packages:
+
+Add `trmt` to your flake as an input,
 ```nix
 {
   inputs = {
     ... # other inputs
     trmt.url = "github:cenonym/trmt";
   };
+}
+```
 
+Then, you can add `inputs.trmt.packages.${pkgs.systems}.default` directly into your `environment.systemPackages` or `home.packages`:
+```nix
+{
   outputs = { nixpkgs, trmt, ... }: {
     nixosConfigurations.<mysystem> = nixpkgs.lib.nixosSystem {
       modules = [
@@ -70,6 +76,57 @@ Add `trmt` to your flake as an input, and then add it to your packages:
   };
 }
 ```
+
+<details>
+<summary>Installing and configuring trmt with home-manager</summary>
+
+You can also use the `home-manager` module to install and configure `trmt`. First, you need to add `inputs.trmt.homeManagerModules.default` to your imports in your `home-manager` config, and then you can directly configure `trmt` (it will create the `$XDG_CONFIG_HOME/.config/trmt/config.toml` file for you):
+```nix
+{inputs, ...}: {
+  imports = [
+    inputs.trmt.homeManagerModules.default
+  ];
+
+  programs.trmt = {
+    enable = true;
+    config = {
+      simulation = {
+        heads = 3;
+        rule = "RL";
+        speed_ms = 20;
+        trail_length = 30;
+        color_cells = true;
+        seed = "";
+      };
+      display = {
+        colors = ["rgb(241, 113, 54)" "#45a8e9" "229"];
+        fade_trail_color = "";
+        state_based_colors = false;
+        live_colors = false;
+        head_char = ["██"];
+        trail_char = ["▓▓"];
+        cell_char = "░░";
+        randomize_heads = false;
+        randomize_trails = false;
+      };
+      controls = {
+        quit = "q";
+        toggle = " ";
+        reset = "r";
+        faster = "+";
+        slower = "-";
+        config_reload = "c";
+        help = "h";
+        statusbar = "b";
+        seed_toggle = "s";
+        rule_toggle = "n";
+      };
+    };
+  };
+}
+```
+
+</details>
 <br>
 
 **Install from source**

--- a/flake.lock
+++ b/flake.lock
@@ -1,41 +1,20 @@
 {
   "nodes": {
-    "fenix": {
+    "flake-parts": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1749537578,
-        "narHash": "sha256-dYEEiNRw7rClQi4Y7t9jlHjbuUvSbdTdM/jXwXuaDeQ=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "5e3ce25aa3048f14f206a6c4fab46af6ad939482",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -55,43 +34,25 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "fenix": "fenix",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1749493129,
-        "narHash": "sha256-nQ+gKRLXkl7gLY836ULyAwR3O0E/+vakZt78OQ+p9Fc=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "bf6d44581085bb9b6e285902a7fae77325703171",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,39 +3,41 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
   outputs = {
     self,
     nixpkgs,
-    flake-utils,
-    fenix,
-  }:
-    flake-utils.lib.eachDefaultSystem
-    (
-      system: let
-        pkgs = nixpkgs.legacyPackages.${system};
-        toolchain = fenix.packages.${system}.minimal.toolchain;
-        rustPlatform = pkgs.makeRustPlatform {
-          cargo = toolchain;
-          rustc = toolchain;
-        };
-        cargoToml = pkgs.lib.importTOML ./Cargo.toml;
-      in {
-        packages = rec {
-          trmt = rustPlatform.buildRustPackage {
-            pname = cargoToml.package.name;
-            version = cargoToml.package.version;
-            src = ./.;
-            cargoLock.lockFile = ./Cargo.lock;
-          };
+    flake-parts,
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} (top @ {
+      config,
+      withSystem,
+      moduleWithSystem,
+      ...
+    }: {
+      flake = {
+        homeManagerModules = rec {
+          trmt = import ./nix/modules/home-manager.nix self;
           default = trmt;
         };
-      }
-    );
+      };
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem = {
+        config,
+        pkgs,
+        ...
+      }: {
+        packages = rec {
+          trmt = pkgs.callPackage ./nix/package.nix {};
+          default = trmt;
+        };
+      };
+    });
 }

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -1,0 +1,67 @@
+self: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.trmt;
+  settingsFormat = pkgs.formats.toml {};
+in {
+  options.programs.trmt = {
+    enable = lib.mkEnableOption "trmt; 2D Turing machine (turmite) for your terminal, written in Rust";
+
+    package = lib.mkPackageOption self.packages.${pkgs.system} "trmt" {
+      default = "default";
+      pkgsText = "trmt.packages.\${system}";
+    };
+
+    config = lib.mkOption {
+      type = settingsFormat.type;
+      example = lib.literalExpression ''
+        {
+          simulation = {
+            heads = 3;
+            rule = "RL";
+            speed_ms = 20;
+            trail_length = 24;
+            color_cells = true;
+            seed = "";
+          };
+          display = {
+            colors = ["rgb(241, 113, 54)" "#45a8e9" "229"];
+            fade_trail_color = "";
+            state_based_colors = false;
+            live_colors = false;
+            head_char = ["██"];
+            trail_char = ["▓▓"];
+            cell_char = "░░";
+            randomize_heads = false;
+            randomize_trails = false;
+          };
+          controls = {
+            quit = "q";
+            toggle = " ";
+            reset = "r";
+            faster = "+";
+            slower = "-";
+            config_reload = "c";
+            help = "h";
+            statusbar = "b";
+            seed_toggle = "s";
+            rule_toggle = "n";
+          };
+        };
+      '';
+      description = ''
+        trmt configuration.
+        For available settings, see <https://github.com/cenonym/trmt?tab=readme-ov-file#config-options>.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [cfg.package];
+
+    xdg.configFile."trmt/config.toml".source = settingsFormat.generate "config.toml" cfg.config;
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,12 @@
+{
+  lib,
+  rustPlatform,
+}: let
+  cargoToml = lib.importTOML ../Cargo.toml;
+in
+  rustPlatform.buildRustPackage (finalAttrs: {
+    pname = "trmt";
+    version = cargoToml.package.version;
+    src = ../.;
+    cargoLock.lockFile = ../Cargo.lock;
+  })


### PR DESCRIPTION
The related discussion can be found #9.

Hi @cenonym!

This PR adds support for configuring trmt directly using `homeManagerModules`.

I think the recent changes look pretty neat! I've tested them, and it seems to be working pretty nicely! Since we are not directly modifying the config file from the program anymore (except for when there is no config file, which I think is a reasonable exception), like you've also indicated, there is nothing that prevents us for creating a home-manager module!

_Just so you know, currently, this PR assumes that the `main` branch has these changes and if a user tries to use this before these changes are merged, the example config in the README will not work for them. I am not quite sure as to when the `dev` branch will be merged, but if you are planning to keep it for some time, please let me know and I can, temporarily, change the flake to account for this--it is actually a one line change, instead of `trmt.url = "github:cenonym/trmt";`, we need `trmt.url = "github:cenonym/trmt?ref=dev";`._

Thanks again!